### PR TITLE
refactor to fix state bug, moved category filter to ReviewSort component

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -93,6 +93,9 @@
 .home-page {
   padding: 0 8px;
 }
+.categories-list li {
+  font-weight: bold;
+}
 
 .sorting-dropdowns {
   padding: 0 8px;

--- a/src/App.js
+++ b/src/App.js
@@ -20,10 +20,7 @@ function App() {
         <Route path="/reviews/:category" element={<Reviews />} />
         <Route path="/review/:review_id" element={<SingleReview />} />
         <Route path="/sign-in" element={<SignIn />} />
-        <Route
-          path="/review/:review_id"
-          element={<SingleReview user={user} setUser={setUser} />}
-        />
+        <Route path="/review/:review_id" element={<SingleReview />} />
         <Route path="*" element={<NotFoundErr />} />
       </Routes>
     </div>

--- a/src/components/HomePage.jsx
+++ b/src/components/HomePage.jsx
@@ -1,35 +1,46 @@
-import { Link } from "react-router-dom";
-
 const HomePage = () => {
   return (
     <div className="home-page">
       <h2>Welcome to NC Games!</h2>
-
-      <ul>
-        <h4 className="home-category-header">
-          Looking for something specific?
-        </h4>
-        <li>
-          <Link to={"/reviews/dexterity"}>Dexterity</Link>
-        </li>
-        <li>
-          <Link to={"/reviews/strategy"}>Strategy</Link>
-        </li>
-        <li>
-          <Link to={"/reviews/hidden-roles"}>Hidden Roles</Link>
-        </li>
-        <li>
-          <Link to={"/reviews/push-your-luck"}>Push your luck</Link>
-        </li>
-        <li>
-          <Link to={"/reviews/roll-and-write"}>Roll and write</Link>
-        </li>
-        <li>
-          <Link to={"/reviews/deck-building"}>Deck Building</Link>
-        </li>
-        <li>
-          <Link to={"/reviews/engine-building"}>Engine Building</Link>
-        </li>
+      <p>
+        For all your board game review needs! Browse for your favourite board
+        games and see what people are saying about them, or look for something
+        that may become a new staple of your Saturday nights!
+      </p>
+      <h3>Genres on offer</h3>
+      <ul className="categories-list">
+        <section className="categories">
+          <li>Dexterity</li>
+          <p>
+            Games about testing your reactions, and your abilty to physically
+            manipulate game pieces to win!
+          </p>
+          <li>Strategy</li>
+          <p>
+            Go head-to-head with your opponents to outsmart them in a game of
+            wits.
+          </p>
+          <li> Hidden Roles</li>
+          <p>Who is the imposter?</p>
+          <li>Push Your Luck</li>
+          <p>
+            Should you or should you not take another turn? That is the
+            question.
+          </p>
+          <li>Roll and Write</li>
+          <p>Roll the dice and leave it up to fate!</p>
+          <li>Deck Building</li>
+          <p>
+            Build up your deck to take on other players, these games usually
+            involve a lot of strategy and deep knowlodge of the games rules to
+            win.
+          </p>
+          <li>Engine Building</li>
+          <p>
+            Build up your resourses, money or points to overwhelm your opponents
+            and emerge victorious
+          </p>
+        </section>
       </ul>
     </div>
   );

--- a/src/components/ReviewSort.jsx
+++ b/src/components/ReviewSort.jsx
@@ -16,11 +16,17 @@ const ReviewSort = ({ setReviews }) => {
     setSearchParams(searchParams);
   };
 
+  const handleCategory = (event) => {
+    searchParams.set("category", event.target.value);
+    setSearchParams(searchParams);
+  };
+
   useEffect(() => {
     setIsLoading(true);
     getSortedReviews(
       searchParams.get("sort_by") || "title",
-      searchParams.get("order") || "asc"
+      searchParams.get("order") || "asc",
+      searchParams.get("category")
     ).then((reviews) => {
       setIsLoading(false);
       setReviews(reviews);
@@ -42,7 +48,7 @@ const ReviewSort = ({ setReviews }) => {
         >
           <option value="title">Title</option>
           <option value="designer">Designer</option>
-          <option value="category">Category</option>
+
           <option value="votes">Votes</option>
           <option value="comment_count">Comment Count</option>
         </select>
@@ -58,6 +64,25 @@ const ReviewSort = ({ setReviews }) => {
         >
           <option value="desc">Descending</option>
           <option value="asc">Ascending</option>
+        </select>
+      </label>
+      <label className="category-sort" htmlFor="category-option">
+        Category:{" "}
+        <select
+          onChange={handleCategory}
+          value={searchParams.get("category") || "all"}
+          name="category"
+          id="category-option"
+          className="category-dropdown"
+        >
+          <option value="all">All</option>
+          <option value="dexterity">Dexterity</option>
+          <option value="strategy">Strategy</option>
+          <option value="hidden-roles">Hidden Roles</option>
+          <option value="push-your-luck">Push Your Luck</option>
+          <option value="roll-and-write">Roll and Write</option>
+          <option value="deck-building">Deck Building</option>
+          <option value="engine-building">Engine Building</option>
         </select>
       </label>
     </section>

--- a/src/components/Reviews.jsx
+++ b/src/components/Reviews.jsx
@@ -4,7 +4,6 @@ import ReviewsList from "./ReviewsList";
 
 const Reviews = () => {
   const { category } = useParams();
-  //   console.log(category);
   return (
     <section>
       <ReviewsList category={category} />

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -15,9 +15,15 @@ export const getReviews = async (category) => {
   }
 };
 
-export const getSortedReviews = async (sort_by, order) => {
+export const getSortedReviews = async (sort_by, order, category) => {
+  if (category === "all") {
+    const { data } = await gamesApi.get("/reviews", {
+      params: { sort_by, order },
+    });
+    return data.reviews;
+  }
   const { data } = await gamesApi.get("/reviews", {
-    params: { sort_by, order },
+    params: { sort_by, order, category },
   });
   return data.reviews;
 };
@@ -60,6 +66,5 @@ export const getUsers = async () => {
 
 export const getUsersByUsername = async (user_name) => {
   const { data } = await gamesApi.get(`/users/${user_name}`);
-  console.log(data);
   return data.user;
 };


### PR DESCRIPTION
To fix the reviews state being re-set when linked from the homepage had to move the category filter to the ReviewSort component. Now the category is a dropdown next to the other sort options. Seems to be functioning correctly, when choosing a category only that category will render on the page, other sort options work on that list without error.